### PR TITLE
Upgrade Pennsieve PostgreSQL base Docker image

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.5-alpine
+FROM postgres:16.3-alpine
 
 USER root
 

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: pennsieve/postgres:12.5
+    image: pennsieve/postgres:16.3
     build: .
   postgreslatest:
     image: pennsieve/postgres:latest


### PR DESCRIPTION
**ClickUp Ticket:** [8688zghwn](https://app.clickup.com/t/8688zghwn)

Part of overall PostgresSQL RDS upgrade to 16.3

### Related PRs
- https://github.com/Pennsieve/pennsieve-api/pull/294
- https://github.com/Pennsieve/discover-pgdump-lambda/pull/1