### PR TITLE
Update Go version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ installer
 installation_key
 license.lic
 output.txt
+/.idea/

--- a/go-cloudwrap/alpine/Dockerfile
+++ b/go-cloudwrap/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.23-alpine
 
 RUN apk update && apk add --no-cache openssl
 

--- a/go-cloudwrap/alpine/docker-compose.yml
+++ b/go-cloudwrap/alpine/docker-compose.yml
@@ -1,8 +1,10 @@
 version: '3'
 services:
   go:
-    image: pennsieve/go-cloudwrap:1.18-alpine
+    image: pennsieve/go-cloudwrap:1.23-alpine
+    platform: linux/amd64
     build: .
   golatest:
-    image: pennsieve/go-cloudwrap:1.18-alpine-latest
+    image: pennsieve/go-cloudwrap:1.23-alpine-latest
+    platform: linux/amd64
     build: .


### PR DESCRIPTION
PR updates Go version from 1.18 to 1.23 in the `cloudwatch-go` Dockerfile. 

Also adds `platform: linux/amd64` option to build for this image to avoid warnings when run on Jenkins.